### PR TITLE
feat: autogenerate .gitignore

### DIFF
--- a/src/init/constants.json
+++ b/src/init/constants.json
@@ -2,6 +2,7 @@
     "artifactsDest": "./",
     "artifactsDir": "/artifacts",
     "updateArtifactsDir": "/update-artifacts",
+    "recommendedGitIgnore":"/recommended-gitignore.txt",
     "dependencies": [
         "@aeternity/aepp-sdk@12"
     ],

--- a/src/init/init.js
+++ b/src/init/init.js
@@ -38,6 +38,7 @@ const createAEprojectProjectStructure = async (folder) => {
 
   await setupArtifacts(folder);
   await installDependencies(folder);
+  await generateGitIgnore(folder);
 
   print('===== aeproject successfully initialized =====');
   print('test/exampleTest.js and contract/ExampleContract.aes have been added as example how to use aeproject');
@@ -93,6 +94,16 @@ const updateArtifacts = async (folder) => {
     }, Promise.resolve());
 
   await copyFolderRecursiveSync(fileSource, folder);
+};
+
+/**
+ * generates a .gitignore file based on the content of
+ * recommended-gitignore.txt
+ * @param {string} folder - folder to add .gitignore
+ */
+const generateGitIgnore = async (folder) => {
+  const gitIgnorePath = path.join(folder, '.gitignore');
+  await fs.promises.copyFile(`${__dirname}${constants.recommendedGitIgnore}`, gitIgnorePath);
 };
 
 module.exports = {

--- a/src/init/recommended-gitignore.txt
+++ b/src/init/recommended-gitignore.txt
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/tests/happy-path.js
+++ b/tests/happy-path.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 const chaiFiles = require('chai-files');
 const { isEnvRunning } = require('../src/env/env');
 const { version } = require('../package.json');
+const constants = require('../src/init/constants.json');
 
 chai.use(chaiFiles);
 const { assert } = chai;
@@ -39,6 +40,10 @@ describe('Happy Path', () => {
     it(folder ? `init ${folder}` : 'init', async () => {
       const res = await exec(folder ? `aeproject init ${folder}` : 'aeproject init', { cwd });
       assert.equal(res.code, 0);
+
+      const generatedGitIgnore = file(path.join(cwd, '.gitignore')).content;
+      const expectedGitIgnore = file(path.join(__dirname, `../src/init/${constants.recommendedGitIgnore}`)).content;
+      assert.equal(generatedGitIgnore, expectedGitIgnore);
 
       // link to use local aeproject utils
       await exec('npm link @aeternity/aeproject', { cwd: folder ? path.join(cwd, folder) : cwd });


### PR DESCRIPTION
closes #446 

Automatically generates a `.gitignore`. Implementation follows the one of hardhat (https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-core/recommended-gitignore.txt) where they keep a `recommended-gitignore.txt` file which content is copied to the generated `.gitignore`.

Another approach would be to create an array of strings (where each item would be line in `.gitignore`) inside `constants.json` however I considered the submitted approach as simpler.