### PR TITLE
refactor: promisify instead promisify-child-process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@aeternity/aepp-sdk": "^14.0.0",
         "commander": "^12.1.0",
-        "promisify-child-process": "^4.1.2",
         "prompts": "^2.4.2"
       },
       "bin": {
@@ -4707,15 +4706,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/promisify-child-process": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-4.1.2.tgz",
-      "integrity": "sha512-APnkIgmaHNJpkAn7k+CrJSi9WMuff5ctYFbD0CO2XIPkM8yO7d/ShouU2clywbpHV/DUsyc4bpJCsNgddNtx4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@aeternity/aepp-sdk": "^14.0.0",
     "commander": "^12.1.0",
-    "promisify-child-process": "^4.1.2",
     "prompts": "^2.4.2"
   },
   "devDependencies": {

--- a/src/init/init.js
+++ b/src/init/init.js
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { exec } from "promisify-child-process";
-import { print } from "../utils/utils.js";
+import { print, exec } from "../utils/utils.js";
 import { copyFolderRecursive, deleteWithPrompt } from "../utils/fs-utils.js";
 import { fileURLToPath } from "url";
 import { readFile } from "fs/promises";

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -1,4 +1,4 @@
-import { exec } from "promisify-child-process";
+import { spawn } from "child_process";
 import { print } from "../utils/utils.js";
 
 async function run() {
@@ -10,11 +10,9 @@ async function run() {
 async function test() {
   print("===== Starting Tests =====");
 
-  const child = exec("npm test");
+  const proc = spawn("npm", ["test"], { stdio: "inherit" });
 
-  child.stdout.on("data", (out) => process.stdout.write(out));
-  child.stderr.on("data", (err) => process.stderr.write(err));
-  await child;
+  await new Promise((resolve) => proc.on("close", resolve));
 }
 
 export default { run };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,2 +1,7 @@
+import { promisify } from "util";
+import { exec as execCb } from "child_process";
+
+export const exec = promisify(execCb);
+
 export const print = console.log;
 export const printError = console.error;

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -11,24 +11,21 @@ describe("command line usage", () => {
   afterAll(() => cleanLocal());
 
   it("help", async () => {
-    const res = await exec("aeproject help", { cwd });
-    assert.equal(res.code, 0);
+    await exec("aeproject help", { cwd });
   });
 
   it("version", async () => {
     const res = await exec("aeproject --version", { cwd });
-    assert.equal(res.code, 0);
     assert.include(res.stdout, version);
   });
 
   for (const folder of [null, "testprojectfolder"]) {
     // eslint-disable-next-line vitest/valid-title
     it(folder ? `init ${folder}` : "init", async () => {
-      const res = await exec(
+      await exec(
         folder ? `aeproject init ${folder}` : "aeproject init",
         { cwd },
       );
-      assert.equal(res.code, 0);
 
       // link to use local aeproject utils
       await linkLocalLib(folder);
@@ -48,8 +45,7 @@ describe("command line usage", () => {
   }
 
   it("env", async () => {
-    const res = await exec("aeproject env", { cwd });
-    assert.equal(res.code, 0);
+    await exec("aeproject env", { cwd });
     assert.isTrue(await isEnvRunning(cwd));
 
     // don't run for all gh-action matrix tests
@@ -75,14 +71,11 @@ describe("command line usage", () => {
 
   it("env --info", async () => {
     const res = await exec("aeproject env --info", { cwd });
-    assert.equal(res.code, 0);
-
     print(res.stdout);
   });
 
   it("test", async () => {
     const res = await exec("aeproject test", { cwd });
-    assert.equal(res.code, 0);
     assert.equal(res.stderr, "");
     assert.include(res.stdout, "2 passing");
   });
@@ -94,7 +87,6 @@ describe("command line usage", () => {
       // link to use local aeproject utils
       await linkLocalLib();
 
-      assert.equal(res.code, 0);
       assert.equal(res.stderr, "");
       assert.include(
         res.stdout,
@@ -115,21 +107,18 @@ describe("command line usage", () => {
       );
 
       const resEnv = await exec("aeproject env", { cwd });
-      assert.equal(resEnv.code, 0);
       assert.isTrue(await isEnvRunning(cwd));
 
       assert.include(resEnv.stdout, "aeternity/aeternity       latest");
       assert.include(resEnv.stdout, "aeternity/aesophia_http   latest");
 
       const resTest = await exec("aeproject test", { cwd });
-      assert.equal(resTest.code, 0);
       assert.include(resTest.stdout, "2 passing");
     } else console.log("skipping next test for auxiliary test run");
   });
 
   it("env --stop", async () => {
-    const res = await exec("aeproject env --stop", { cwd });
-    assert.equal(res.code, 0);
+    await exec("aeproject env --stop", { cwd });
     assert.isFalse(await isEnvRunning(cwd));
   });
 });

--- a/tests/util.mjs
+++ b/tests/util.mjs
@@ -1,7 +1,6 @@
 import path from "path";
-
-import { exec as execP } from "promisify-child-process";
 import fs from "fs";
+import { exec as execP } from "../src/utils/utils";
 
 export const cwd = path.join(process.cwd(), ".testdir");
 


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

Implemented according to NodeJS guide https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback

https://nodejs.org/api/child_process.html#child_processspawncommand-args-options

https://www.npmjs.com/package/promisify-child-process